### PR TITLE
[AB2D-6234] Update base image from openjdk:17 to amazoncorretto:17-al2-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM amazoncorretto:17-al2-jdk
 WORKDIR /usr/src/ab2d-contracts
 ADD build/libs/Ab2d-*-Contracts-Service-*.jar /usr/src/ab2d-contracts/ab2d-contracts.jar
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/ab2d-6234

## 🛠 Changes

Update Dockerfile base image from openjdk:17 to amazoncorretto:17-al2-jdk.

## ℹ️ Context

Openjdk:17 image is deprecated and no longer receives security updates. Updating the image to amazoncorretto:17-al2-jdk because that is not deprecated, and it is the base image we are using on ab2d-worker and api, so if it works we will be consistent across projects.

## 🧪 Validation

Deployed to lower environments for testing:
- [x] Deployed and tested on IMPL Environment