### PR TITLE
Upgrade gradle in ab2d jenkins to 7.5

### DIFF
--- a/Jenkinsfile.deployment
+++ b/Jenkinsfile.deployment
@@ -8,7 +8,7 @@ pipeline {
     }
 
     tools {
-        gradle "gradle-7.2"
+        gradle "gradle-7.5"
         jdk 'openjdk17'
     }
     

--- a/Jenkinsfile.testing
+++ b/Jenkinsfile.testing
@@ -1,6 +1,6 @@
 pipeline {
     environment {
-        ARTIFACTORY_URL = credentials('ARTIFACTORY_URL')
+        ARTIFACTORY_URL = credentials('ARTIFACTORY_URL'
         
         // HPMS key id and secret
         HPMS_AUTH_KEY_ID = credentials('HPMS_AUTH_KEY_ID')
@@ -12,7 +12,7 @@ pipeline {
     }
 
     tools {
-        gradle "gradle-7.2"
+        gradle "gradle-7.5"
         jdk 'openjdk17'
     }
 

--- a/Jenkinsfile.testing
+++ b/Jenkinsfile.testing
@@ -1,6 +1,6 @@
 pipeline {
     environment {
-        ARTIFACTORY_URL = credentials('ARTIFACTORY_URL'
+        ARTIFACTORY_URL = credentials('ARTIFACTORY_URL')
         
         // HPMS key id and secret
         HPMS_AUTH_KEY_ID = credentials('HPMS_AUTH_KEY_ID')


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-710

## 🛠 Changes

Updated Jenkinsfile.deployment and Jenkinsfile.testing with gradle "gradle-7.5"

## ℹ️ Context

To upgrade Spring Boot we need to upgrade our gradle version to 7.5. We need to still run 7.2 parallel for the other jobs that require it.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
