### PR TITLE
PLT-944 Get HPMS key and secret from secrets manager

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Unit tests and static analysis
 
 on:
-  push:
   workflow_call:
   workflow_dispatch: # Allow manual trigger
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,19 +39,15 @@ jobs:
             SONAR_TOKEN=/sonarqube/token
 
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        env:
-          ACCOUNT_NAME: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT', env.ACCOUNT_NAME)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT_NAME }}-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.TEST_ACCOUNT }}:role/delegatedadmin/developer/ab2d-test-github-actions
 
       - uses: aws-actions/aws-secretsmanager-get-secrets@fbd65ea98e018858715f591f03b251f02b2316cb #v2.0.8
-        env:
-          SECRET_ENV: ${{ env.DEPLOYMENT_ENV == 'east-prod-test' && 'east-prod' || env.DEPLOYMENT_ENV }}
         with:
           secret-ids: |
-            HPMS_AUTH_KEY_ID, ab2d/ab2d-${{ env.SECRET_ENV }}/module/db/ab2d_hpms_auth_key_id/2020-01-02-09-15-01
-            HPMS_AUTH_KEY_SECRET, ab2d/ab2d-${{ env.SECRET_ENV }}/module/db/ab2d_hpms_auth_key_secret/2020-01-02-09-15-01
+            HPMS_AUTH_KEY_ID, ab2d/ab2d-east-impl/module/db/ab2d_hpms_auth_key_id/2020-01-02-09-15-01
+            HPMS_AUTH_KEY_SECRET, ab2d/ab2d-east-impl/module/db/ab2d_hpms_auth_key_secret/2020-01-02-09-15-01
 
       - name: Build files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Unit tests and static analysis
 
 on:
+  push:
   workflow_call:
   workflow_dispatch: # Allow manual trigger
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
 
       - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
         with:
@@ -37,21 +37,33 @@ jobs:
             ARTIFACTORY_PASSWORD=/artifactory/password
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
-            HPMS_AUTH_KEY_ID=/hpms/id
-            HPMS_AUTH_KEY_SECRET=/hpms/secret
-            
+
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        env:
+          ACCOUNT_NAME: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT', env.ACCOUNT_NAME)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT_NAME }}-github-actions
+
+      - uses: aws-actions/aws-secretsmanager-get-secrets@fbd65ea98e018858715f591f03b251f02b2316cb #v2.0.8
+        env:
+          SECRET_ENV: ${{ env.DEPLOYMENT_ENV == 'east-prod-test' && 'east-prod' || env.DEPLOYMENT_ENV }}
+        with:
+          secret-ids: |
+            HPMS_AUTH_KEY_ID, ab2d/ab2d-${{ env.SECRET_ENV }}/module/db/ab2d_hpms_auth_key_id/2020-01-02-09-15-01
+            HPMS_AUTH_KEY_SECRET, ab2d/ab2d-${{ env.SECRET_ENV }}/module/db/ab2d_hpms_auth_key_secret/2020-01-02-09-15-01
 
       - name: Build files
         run: |
-          gradle build -x test --info 
+          gradle build -x test --info
 
       - name: Do tests
         run: |
-          gradle clean test --info build 
+          gradle clean test --info build
 
       - name: Build Jar
         run: |
-          gradle jar --info build 
+          gradle jar --info build
 
       - name: Gradle task
         run: |
@@ -63,10 +75,10 @@ jobs:
             -Dsonar.projectKey=ab2d-contracts \
             -Dsonar.host.url=https://sonarqube.cloud.cms.gov \
             -Dsonar.login=$SONAR_TOKEN
-            
+
       - name: Quality Gate
         id: sonarqube-quality-gate-check
         uses: sonarsource/sonarqube-quality-gate-action@master
         with:
           scanMetadataReportFile: build/sonar/report-task.txt
-        timeout-minutes: 10 
+        timeout-minutes: 10


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-944

## 🛠 Changes

Gets the HPMS auth key and secret from secrets manager for tests.

## ℹ️ Context

Allows for us to only keep HPMS key and secret in one place in AWS, rather than maintaining in multiple locations.

## 🧪 Validation

See checks.